### PR TITLE
[184234029] Add contify timeout in Connection.request/2

### DIFF
--- a/lib/contify_api/connection.ex
+++ b/lib/contify_api/connection.ex
@@ -38,7 +38,11 @@ defmodule ContifyAPI.Connection do
 
   @doc "Forward requests to Tesla."
   @spec request(Tesla.Client.t(), [Tesla.option()]) :: Tesla.Env.result()
-  defdelegate request(client, options), to: Tesla
+  def request(client, options) do
+    timeout = Application.get_env(:contify, :timeout, @default_timeout)
+    options = options |> Keyword.merge(opts: [adapter: [timeout: timeout]])
+    Tesla.request(client, options)
+  end
 
   @doc """
   Configure a client with no authentication.


### PR DESCRIPTION
Realized the default adapter is actually `Tesla.Adapter.Httpc`, `not Tesla.Adapter.Hackney`.
Tested this in iex using [this SO thread as a reference](https://stackoverflow.com/a/100859), and it seemed to work ok with just the Middleware (?). :
```elixir
iex(31)> IO.inspect(DateTime.utc_now()); Tesla.client([{Tesla.Middleware.Timeout, timeout: 90000}], Tesla.Adapte
r.Httpc) |> Tesla.request(method: :get, url: "https://www.google.com:81") |> IO.inspect(); IO.inspect(DateTime.u
tc_now()) 
~U[2023-01-17 14:47:13.463563Z]
{:error, :timeout}
~U[2023-01-17 14:48:43.465761Z]
```
Anyway I figured using finch was adding an unnecessary extra dependency and this was taking too long to test (I don't know if it's a connection timeout or a request timeout which I guess we'd have to test by doing a dummy server), so I just went back to this solution.