### PR TITLE
184366331 Contify: subscribe_to_webhook returns :ok on error responses.

### DIFF
--- a/lib/contify.ex
+++ b/lib/contify.ex
@@ -27,9 +27,9 @@ defmodule Contify do
           | {:error, Tesla.Env.t()}
   @type webhook :: map
   @type webhook_response ::
-          {:ok, ContifyAPI.Model.Error.t()}
-          | {:ok, ContifyAPI.Model.WebhooksResponse.t()}
+          {:ok, ContifyAPI.Model.WebhooksResponse.t()}
           | {:ok, String.t()}
+          | {:error, ContifyAPI.Model.Error.t()}
           | {:error, Tesla.Env.t()}
 
   @doc """

--- a/lib/contify_api/api/webhooks.ex
+++ b/lib/contify_api/api/webhooks.ex
@@ -192,9 +192,9 @@ defmodule ContifyAPI.Api.Webhooks do
   - `{:error, Tesla.Env.t}` on failure
   """
   @spec webhook_post(Tesla.Env.client(), ContifyAPI.Model.WebhookGetRequest.t(), keyword()) ::
-          {:ok, ContifyAPI.Model.Error.t()}
-          | {:ok, ContifyAPI.Model.WebhooksResponse.t()}
+          {:ok, ContifyAPI.Model.WebhooksResponse.t()}
           | {:ok, String.t()}
+          | {:error, ContifyAPI.Model.Error.t()}
           | {:error, Tesla.Env.t()}
   def webhook_post(connection, webhook, _opts \\ []) do
     webhook =

--- a/lib/contify_api/connection.ex
+++ b/lib/contify_api/connection.ex
@@ -105,7 +105,9 @@ defmodule ContifyAPI.Connection do
     app_secret = app_secret()
     app_id = app_id()
 
-    if Mix.env() == :test do
+    timeout = Application.get_env(:contify, :timeout, @default_timeout)
+
+    if timeout == 0 do
       [
         {Tesla.Middleware.BaseUrl, base_url},
         {Tesla.Middleware.Headers, [{"user-agent", user_agent}]},
@@ -115,8 +117,6 @@ defmodule ContifyAPI.Connection do
         | middleware
       ]
     else
-      timeout = Application.get_env(:contify, :timeout, @default_timeout)
-
       [
         {Tesla.Middleware.BaseUrl, base_url},
         {Tesla.Middleware.Headers, [{"user-agent", user_agent}]},

--- a/lib/contify_api/connection.ex
+++ b/lib/contify_api/connection.ex
@@ -105,17 +105,28 @@ defmodule ContifyAPI.Connection do
     app_secret = app_secret()
     app_id = app_id()
 
-    timeout = Application.get_env(:contify, :timeout, @default_timeout)
+    if Mix.env() == :test do
+      [
+        {Tesla.Middleware.BaseUrl, base_url},
+        {Tesla.Middleware.Headers, [{"user-agent", user_agent}]},
+        {Tesla.Middleware.Headers, [{"APPSECRET", app_secret}]},
+        {Tesla.Middleware.Headers, [{"APPID", app_id}]},
+        {Tesla.Middleware.EncodeJson, engine: json_engine}
+        | middleware
+      ]
+    else
+      timeout = Application.get_env(:contify, :timeout, @default_timeout)
 
-    [
-      {Tesla.Middleware.BaseUrl, base_url},
-      {Tesla.Middleware.Headers, [{"user-agent", user_agent}]},
-      {Tesla.Middleware.Headers, [{"APPSECRET", app_secret}]},
-      {Tesla.Middleware.Headers, [{"APPID", app_id}]},
-      {Tesla.Middleware.Timeout, timeout: timeout},
-      {Tesla.Middleware.EncodeJson, engine: json_engine}
-      | middleware
-    ]
+      [
+        {Tesla.Middleware.BaseUrl, base_url},
+        {Tesla.Middleware.Headers, [{"user-agent", user_agent}]},
+        {Tesla.Middleware.Headers, [{"APPSECRET", app_secret}]},
+        {Tesla.Middleware.Headers, [{"APPID", app_id}]},
+        {Tesla.Middleware.Timeout, timeout: timeout},
+        {Tesla.Middleware.EncodeJson, engine: json_engine}
+        | middleware
+      ]
+    end
   end
 
   @doc """

--- a/test/contify_test.exs
+++ b/test/contify_test.exs
@@ -58,11 +58,55 @@ defmodule ContifyTest do
     end
   end
 
+  describe "existing webhooks" do
+    setup do
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{
+            status: 100,
+            body:
+              ~s({"code":100, "message": "Internal Error. Please check if you are providing all necessary details.", "fields": ""}
+            )
+          }
+      end)
+
+      :ok
+    end
+
+    test "subscribe to webhook" do
+      params = %{
+        name: "some name",
+        url: "some endpoint",
+        headerName: "",
+        headerValue: "",
+        companyId: 678,
+        industryId: "",
+        contentTypeId: "",
+        locationId: "",
+        sourceId: "",
+        channelId: "",
+        topicId: "",
+        customTopicId: "",
+        languageId: "",
+        keyword: "",
+        advancedQuery: ""
+      }
+
+      assert {:error,
+              %ContifyAPI.Model.Error{
+                code: 100,
+                fields: "",
+                message:
+                  "Internal Error. Please check if you are providing all necessary details."
+              }} = Contify.subscribe_to_webhook(params)
+    end
+  end
+
   describe "search_company" do
     setup do
       Tesla.Mock.mock(fn
         %{method: :get} ->
-          %Tesla.Env{status: 200, body: ~s({ 
+          %Tesla.Env{status: 200, body: ~s({
              "count": 30,
              "next": "?page=2",
              "previous": null,

--- a/test/contify_test.exs
+++ b/test/contify_test.exs
@@ -63,7 +63,7 @@ defmodule ContifyTest do
       Tesla.Mock.mock(fn
         %{method: :post} ->
           %Tesla.Env{
-            status: 100,
+            status: 500,
             body:
               ~s({"code":100, "message": "Internal Error. Please check if you are providing all necessary details.", "fields": ""}
             )

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
 ExUnit.start()
+Application.put_env(:contify, :timeout, 0)


### PR DESCRIPTION
# Comment
Let me know if you see any issues.

Manually tested with a couple of Enaia's existing webhooks and the returned response looked like what you specified:
```elixir
{:error,
 %ContifyAPI.Model.Error{
   code: 100,
   fields: "",
   message: "Internal Error. Please check if you are providing all necessary details."
 }}
 ```
 
 Cheers.